### PR TITLE
add option --js-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "assert-never": "^1.2.0",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "commander": "^2.20.0",
+    "commander": "^9.3.0",
     "commondir": "^1.0.1",
     "escape-string-regexp": "^2.0.0",
     "glob": "^7.1.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as commander from 'commander';
+import {Command, Option} from 'commander';
 import {slice2ts} from './index';
 const packageJson = require('../package.json');
 
@@ -12,7 +12,7 @@ function repeatable(value: string, values: string[]) {
   return values;
 }
 
-const program = commander
+const program = new Command()
   .version(packageJson.version)
   .usage('[options] <file ...>')
   .option('--root-dir <dir>', rootDirsDesc, repeatable, [])
@@ -24,6 +24,7 @@ const program = commander
   )
   .option('-o, --out-dir <dir>', 'Directory where to put generated files.')
   .option('--no-js', 'If true, only the typings are generated.')
+  .addOption(new Option('--js-modules <type>', 'Set the type of generated js modules.').choices(['cjs', 'esm']).default('cjs'))
   .option(
     '--ice-imports',
     'If true, Ice modules are imported from particular files instead of "ice".',
@@ -45,16 +46,19 @@ const program = commander
   )
   .parse(process.argv);
 
+const options = program.opts();
+
 slice2ts({
   files: program.args,
-  exclude: program.exclude,
-  rootDirs: program.rootDir,
-  outDir: program.outDir,
-  noJs: !program.js,
-  ignore: program.ignore,
-  index: program.index,
-  iceImports: program.iceImports,
-  noNullableValues: !program.nullableValues,
+  exclude: options.exclude,
+  rootDirs: options.rootDir,
+  outDir: options.outDir,
+  noJs: !options.js,
+  jsModules: options.jsModules,
+  ignore: options.ignore,
+  index: options.index,
+  iceImports: options.iceImports,
+  noNullableValues: !options.nullableValues,
 }).catch(error => {
   console.log(error);
   process.exit(1);

--- a/src/generateJs.ts
+++ b/src/generateJs.ts
@@ -14,6 +14,7 @@ export async function generateJs(
   sliceName: string,
   slices: LoadedSlices,
   absRootDirs: string[],
+  modules: 'cjs' | 'esm'
 ): Promise<string> {
   let compiled = await compileSliceWithEs6(
     sliceName,
@@ -26,15 +27,17 @@ export async function generateJs(
     generateImports(sliceName, slices) + compiled.replace(importRegex, '');
 
   // transform imports to require
-  compiled = babel.transform(compiled, {
-    babelrc: false,
-    plugins: [
-      [
-        require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
-        {noInterop: true},
+  if (modules === 'cjs') {
+    compiled = babel.transform(compiled, {
+      babelrc: false,
+      plugins: [
+        [
+          require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
+          {noInterop: true},
+        ],
       ],
-    ],
-  }).code!;
+    }).code!;
+  }
 
   return compiled;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,14 @@ export interface Slice2TsOptions {
    * If true, only typings are generated.
    */
   noJs?: boolean;
+  
+  /**
+   * The type of generated js modules.
+   * Allowed values are 'cjs' or 'esm'.
+   * @default 'cjs'
+   */
+  jsModules?: 'cjs' | 'esm';
+
   /**
    * If true, Ice modules are imported from particular files instead of "ice".
    */
@@ -113,7 +121,7 @@ export async function slice2ts(options: Slice2TsOptions) {
     if (!options.noJs) {
       await writeFile(
         `${basename}.js`,
-        await generateJs(name, slices, absRootDirs),
+        await generateJs(name, slices, absRootDirs, options.jsModules || 'cjs'),
       );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,10 +1009,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+commander@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
+  integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
 
 commander@~2.20.3:
   version "2.20.3"


### PR DESCRIPTION
Also updated `commander` package for displaying available options

```
PS D:\work\slice2ts> node '.\lib\cli.js' --help
Usage: cli [options] <file ...>

Options:
  -V, --version         output the version number
  --root-dir <dir>      Root dirs.
                        Output files will have the same structure as source files relative to root dirs.
                        Ice includes are also resolved in these dirs. (default: [])
  -e, --exclude <file>  File paths or globs to exclude. (default: [])
  -o, --out-dir <dir>   Directory where to put generated files.
  --no-js               If true, only the typings are generated.
  --js-modules <type>   Set the type of generated js modules. (choices: "cjs", "esm", default: "cjs")
  --ice-imports         If true, Ice modules are imported from particular files instead of "ice".
  -i, --ignore <type>   Don't generate typings for these types. (default: [])
  --index               If true, generates index file for each top-level slice module.
  --no-nullable-values  If true, don't generate `| null` for fields and parameters whose type is Value
  -h, --help            display help for command
```